### PR TITLE
POM file correction for maven projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,15 +22,6 @@ lazy val checkStyleBeforeCompile = TaskKey[Unit](
 
 val pomInfo = (
   <url>https://github.com/janstenpickle/scala-vault</url>
-  <licenses>
-    <license>
-      <name>The MIT License (MIT)</name>
-      <url>
-        https://github.com/janstenpickle/scala-vault/blob/master/LICENSE
-      </url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
   <scm>
     <url>git@github.com:janstenpickle/scala-vault.git</url>
     <connection>
@@ -46,7 +37,7 @@ val pomInfo = (
 )
 
 lazy val commonSettings = Seq(
-  version := "0.4.0",
+  version := "0.4.1-SNAPSHOT",
   scalaVersion := "2.11.8",
   organization := "janstenpickle.vault",
   pomExtra := pomInfo,


### PR DESCRIPTION
Scala projects defined by a maven `pom.xml` file fail to resolve transitive dependencies due to the `<licenses>` tag begin duplicated in the generated POM file. 

Sample complaints from `mvn`: 
```
[WARNING] The POM for janstenpickle.vault:vault-core_2.11:jar:0.4.0 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model
[FATAL] Non-parseable POM /Users/joescii/.m2/repository/janstenpickle/vault/vault-core_2.11/0.4.0/vault-core_2.11-0.4.0.pom: Duplicated tag: 'licenses' (position: START_TAG seen ...</url>\n    <licenses>... @21:15)  @ line 21, column 15

[WARNING] The POM for janstenpickle.vault:vault-auth_2.11:jar:0.4.0 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model
[FATAL] Non-parseable POM /Users/joescii/.m2/repository/janstenpickle/vault/vault-auth_2.11/0.4.0/vault-auth_2.11-0.4.0.pom: Duplicated tag: 'licenses' (position: START_TAG seen ...</url>\n    <licenses>... @21:15)  @ line 21, column 15

[WARNING] The POM for janstenpickle.vault:vault-manage_2.11:jar:0.4.0 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model
[FATAL] Non-parseable POM /Users/joescii/.m2/repository/janstenpickle/vault/vault-manage_2.11/0.4.0/vault-manage_2.11-0.4.0.pom: Duplicated tag: 'licenses' (position: START_TAG seen ...</url>\n    <licenses>... @21:15)  @ line 21, column 15
```

This PR removes the redundant entry from the `pomExtra` setting.