### PR TITLE
wip: Use cats instead of uscala

### DIFF
--- a/auth/src/it/scala/janstenpickle/vault/auth/UserPassIT.scala
+++ b/auth/src/it/scala/janstenpickle/vault/auth/UserPassIT.scala
@@ -1,78 +1,78 @@
-package janstenpickle.vault.auth
-
-import janstenpickle.vault.core.VaultSpec
-import janstenpickle.vault.manage.Auth
-import org.scalacheck.{Gen, Prop}
-import org.specs2.ScalaCheck
-import org.specs2.matcher.MatchResult
-
-class UserPassIT extends VaultSpec with ScalaCheck {
-  import VaultSpec._
-
-  override def is =
-    s2"""
-      Can authenticate a user against a specific "client" path $authPass
-      Fails to authenticate a user $end
-        against a bad "client" path $badClient
-        with a non-existent username $badUser
-        with a bad password $badPassword
-    """
-
-  lazy val underTest = UserPass(config.wsClient)
-  lazy val authAdmin = Auth(config)
-  lazy val userAdmin = janstenpickle.vault.manage.UserPass(config)
-
-  def setupClient(client: String) = authAdmin.enable("userpass", Some(client))
-    .attemptRun(_.getMessage()) must beOk
-
-  def setupUser(username: String, password: String, client: String) =
-    userAdmin.create(username, password, 30, None, client)
-    .attemptRun(_.getMessage())
-
-  def removeClient(client: String) =
-    authAdmin.disable(client).attemptRun(_.getMessage()) must beOk
-
-  def authPass = test((username, password, client, ttl) =>
-                        setupClient(client) and
-    (setupUser(username, password, client) must beOk) and
-    (underTest.authenticate(username, password, ttl, client)
-    .attemptRun(_.getMessage()) must beOk) and
-    removeClient(client)
-  )
-
-  // TODO: test below may fail rarely (e.g. client is same as badClientName)
-
-  def badClient = test{ (username, password, client, ttl) =>
-    val badClientName = "nic-kim-cage-client"
-    setupClient(badClientName) and
-    (setupUser(username, password, client) must beFail) and
-    (underTest.authenticate(username, password, ttl, client)
-    .attemptRun(_.getMessage()) must beFail) and
-    removeClient(badClientName)
-  }
-
-  def badUser = test{ (username, password, client, ttl) =>
-    val badUserName = "nic-kim-cage-user"
-    setupClient(client) and
-    (setupUser(username, password, client) must beOk) and
-    (underTest.authenticate(badUserName, password, ttl, client)
-    .attemptRun(_.getMessage()) must beFail) and
-    removeClient(client)
-  }
-
-  def badPassword = test{ (username, password, client, ttl) =>
-    val badPasswordValue = "nic-kim-cage-password"
-    setupClient(client) and
-    (setupUser(username, password, client) must beOk) and
-    (underTest.authenticate(username, badPasswordValue, ttl, client)
-    .attemptRun(_.getMessage()) must beFail) and
-    removeClient(client)
-  }
-
-  def test(op: (String, String, String, Int) => MatchResult[Any]) =
-    Prop.forAllNoShrink(
-      longerStrGen,
-      longerStrGen,
-      Gen.numStr.suchThat(_.nonEmpty), Gen.posNum[Int]
-    )(op)
-}
+//package janstenpickle.vault.auth
+//
+//import janstenpickle.vault.core.VaultSpec
+//import janstenpickle.vault.manage.Auth
+//import org.scalacheck.{Gen, Prop}
+//import org.specs2.ScalaCheck
+//import org.specs2.matcher.MatchResult
+//
+//class UserPassIT extends VaultSpec with ScalaCheck {
+//  import VaultSpec._
+//
+//  override def is =
+//    s2"""
+//      Can authenticate a user against a specific "client" path $authPass
+//      Fails to authenticate a user $end
+//        against a bad "client" path $badClient
+//        with a non-existent username $badUser
+//        with a bad password $badPassword
+//    """
+//
+//  lazy val underTest = UserPass(config.wsClient)
+//  lazy val authAdmin = Auth(config)
+//  lazy val userAdmin = janstenpickle.vault.manage.UserPass(config)
+//
+//  def setupClient(client: String) = authAdmin.enable("userpass", Some(client))
+//    .attemptRun(_.getMessage()) must beOk
+//
+//  def setupUser(username: String, password: String, client: String) =
+//    userAdmin.create(username, password, 30, None, client)
+//    .attemptRun(_.getMessage())
+//
+//  def removeClient(client: String) =
+//    authAdmin.disable(client).attemptRun(_.getMessage()) must beOk
+//
+//  def authPass = test((username, password, client, ttl) =>
+//                        setupClient(client) and
+//    (setupUser(username, password, client) must beOk) and
+//    (underTest.authenticate(username, password, ttl, client)
+//    .attemptRun(_.getMessage()) must beOk) and
+//    removeClient(client)
+//  )
+//
+//  // TODO: test below may fail rarely (e.g. client is same as badClientName)
+//
+//  def badClient = test{ (username, password, client, ttl) =>
+//    val badClientName = "nic-kim-cage-client"
+//    setupClient(badClientName) and
+//    (setupUser(username, password, client) must beFail) and
+//    (underTest.authenticate(username, password, ttl, client)
+//    .attemptRun(_.getMessage()) must beFail) and
+//    removeClient(badClientName)
+//  }
+//
+//  def badUser = test{ (username, password, client, ttl) =>
+//    val badUserName = "nic-kim-cage-user"
+//    setupClient(client) and
+//    (setupUser(username, password, client) must beOk) and
+//    (underTest.authenticate(badUserName, password, ttl, client)
+//    .attemptRun(_.getMessage()) must beFail) and
+//    removeClient(client)
+//  }
+//
+//  def badPassword = test{ (username, password, client, ttl) =>
+//    val badPasswordValue = "nic-kim-cage-password"
+//    setupClient(client) and
+//    (setupUser(username, password, client) must beOk) and
+//    (underTest.authenticate(username, badPasswordValue, ttl, client)
+//    .attemptRun(_.getMessage()) must beFail) and
+//    removeClient(client)
+//  }
+//
+//  def test(op: (String, String, String, Int) => MatchResult[Any]) =
+//    Prop.forAllNoShrink(
+//      longerStrGen,
+//      longerStrGen,
+//      Gen.numStr.suchThat(_.nonEmpty), Gen.posNum[Int]
+//    )(op)
+//}

--- a/auth/src/it/scala/janstenpickle/vault/auth/UserPassIT.scala
+++ b/auth/src/it/scala/janstenpickle/vault/auth/UserPassIT.scala
@@ -1,78 +1,79 @@
-//package janstenpickle.vault.auth
-//
-//import janstenpickle.vault.core.VaultSpec
-//import janstenpickle.vault.manage.Auth
-//import org.scalacheck.{Gen, Prop}
-//import org.specs2.ScalaCheck
-//import org.specs2.matcher.MatchResult
-//
-//class UserPassIT extends VaultSpec with ScalaCheck {
-//  import VaultSpec._
-//
-//  override def is =
-//    s2"""
-//      Can authenticate a user against a specific "client" path $authPass
-//      Fails to authenticate a user $end
-//        against a bad "client" path $badClient
-//        with a non-existent username $badUser
-//        with a bad password $badPassword
-//    """
-//
-//  lazy val underTest = UserPass(config.wsClient)
-//  lazy val authAdmin = Auth(config)
-//  lazy val userAdmin = janstenpickle.vault.manage.UserPass(config)
-//
-//  def setupClient(client: String) = authAdmin.enable("userpass", Some(client))
-//    .attemptRun(_.getMessage()) must beOk
-//
-//  def setupUser(username: String, password: String, client: String) =
-//    userAdmin.create(username, password, 30, None, client)
-//    .attemptRun(_.getMessage())
-//
-//  def removeClient(client: String) =
-//    authAdmin.disable(client).attemptRun(_.getMessage()) must beOk
-//
-//  def authPass = test((username, password, client, ttl) =>
-//                        setupClient(client) and
-//    (setupUser(username, password, client) must beOk) and
-//    (underTest.authenticate(username, password, ttl, client)
-//    .attemptRun(_.getMessage()) must beOk) and
-//    removeClient(client)
-//  )
-//
-//  // TODO: test below may fail rarely (e.g. client is same as badClientName)
-//
-//  def badClient = test{ (username, password, client, ttl) =>
-//    val badClientName = "nic-kim-cage-client"
-//    setupClient(badClientName) and
-//    (setupUser(username, password, client) must beFail) and
-//    (underTest.authenticate(username, password, ttl, client)
-//    .attemptRun(_.getMessage()) must beFail) and
-//    removeClient(badClientName)
-//  }
-//
-//  def badUser = test{ (username, password, client, ttl) =>
-//    val badUserName = "nic-kim-cage-user"
-//    setupClient(client) and
-//    (setupUser(username, password, client) must beOk) and
-//    (underTest.authenticate(badUserName, password, ttl, client)
-//    .attemptRun(_.getMessage()) must beFail) and
-//    removeClient(client)
-//  }
-//
-//  def badPassword = test{ (username, password, client, ttl) =>
-//    val badPasswordValue = "nic-kim-cage-password"
-//    setupClient(client) and
-//    (setupUser(username, password, client) must beOk) and
-//    (underTest.authenticate(username, badPasswordValue, ttl, client)
-//    .attemptRun(_.getMessage()) must beFail) and
-//    removeClient(client)
-//  }
-//
-//  def test(op: (String, String, String, Int) => MatchResult[Any]) =
-//    Prop.forAllNoShrink(
-//      longerStrGen,
-//      longerStrGen,
-//      Gen.numStr.suchThat(_.nonEmpty), Gen.posNum[Int]
-//    )(op)
-//}
+package janstenpickle.vault.auth
+
+import janstenpickle.scala.syntax.AsyncResultSyntax._
+import janstenpickle.vault.core.VaultSpec
+import janstenpickle.vault.manage.Auth
+import org.scalacheck.{Gen, Prop}
+import org.specs2.ScalaCheck
+import org.specs2.matcher.MatchResult
+
+class UserPassIT extends VaultSpec with ScalaCheck {
+  import VaultSpec._
+
+  override def is =
+    s2"""
+      Can authenticate a user against a specific "client" path $authPass
+      Fails to authenticate a user $end
+        against a bad "client" path $badClient
+        with a non-existent username $badUser
+        with a bad password $badPassword
+    """
+
+  lazy val underTest = UserPass(config.wsClient)
+  lazy val authAdmin = Auth(config)
+  lazy val userAdmin = janstenpickle.vault.manage.UserPass(config)
+
+  def setupClient(client: String) = authAdmin.enable("userpass", Some(client))
+    .attemptRun must beRight
+
+  def setupUser(username: String, password: String, client: String) =
+    userAdmin.create(username, password, 30, None, client)
+      .attemptRun
+
+  def removeClient(client: String) =
+    authAdmin.disable(client).attemptRun must beRight
+
+  def authPass = test((username, password, client, ttl) =>
+                        setupClient(client) and
+    (setupUser(username, password, client) must beRight) and
+    (underTest.authenticate(username, password, ttl, client)
+    .attemptRun must beRight) and
+    removeClient(client)
+  )
+
+  // TODO: test below may fail rarely (e.g. client is same as badClientName)
+
+  def badClient = test{ (username, password, client, ttl) =>
+    val badClientName = "nic-kim-cage-client"
+    setupClient(badClientName) and
+    (setupUser(username, password, client) must beLeft) and
+    (underTest.authenticate(username, password, ttl, client)
+    .attemptRun must beLeft) and
+    removeClient(badClientName)
+  }
+
+  def badUser = test{ (username, password, client, ttl) =>
+    val badUserName = "nic-kim-cage-user"
+    setupClient(client) and
+    (setupUser(username, password, client) must beRight) and
+    (underTest.authenticate(badUserName, password, ttl, client)
+    .attemptRun must beLeft) and
+    removeClient(client)
+  }
+
+  def badPassword = test{ (username, password, client, ttl) =>
+    val badPasswordValue = "nic-kim-cage-password"
+    setupClient(client) and
+    (setupUser(username, password, client) must beRight) and
+    (underTest.authenticate(username, badPasswordValue, ttl, client)
+    .attemptRun must beLeft) and
+    removeClient(client)
+  }
+
+  def test(op: (String, String, String, Int) => MatchResult[Any]) =
+    Prop.forAllNoShrink(
+      longerStrGen,
+      longerStrGen,
+      Gen.numStr.suchThat(_.nonEmpty), Gen.posNum[Int]
+    )(op)
+}

--- a/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
+++ b/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
@@ -5,7 +5,7 @@ import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.vault.core.WSClient
-import uscala.concurrent.result.AsyncResult
+import janstenpickle.scala.Result._
 
 import scala.concurrent.ExecutionContext
 

--- a/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
+++ b/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
@@ -5,7 +5,7 @@ import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.vault.core.WSClient
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 
 import scala.concurrent.ExecutionContext
 

--- a/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
+++ b/auth/src/main/scala/janstenpickle/vault/auth/UserPass.scala
@@ -16,7 +16,7 @@ case class UserPass(wsClient: WSClient) {
     password: String,
     ttl: Int,
     client: String = "userpass"
-  )(implicit ec: ExecutionContext): AsyncResult[String, UserPassResponse] =
+  )(implicit ec: ExecutionContext): AsyncResult[UserPassResponse] =
     wsClient.path(s"auth/$client/login/$username").
       post(Map("password" -> password, "ttl" -> s"${ttl}s")).
       toAsyncResult.

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val scalaVersion212 = "2.12.4"
 
 lazy val specs2Version = "3.8.8"
 lazy val catsVersion = "1.0.1"
-lazy val circeVersion = "0.9.0-M3"
+lazy val circeVersion = "0.9.0"
 lazy val dispatchVersion = "0.11.3"
 lazy val startVaultTask = TaskKey[Unit](
   "startVaultTask",

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val scalaVersion211 = "2.11.11"
 lazy val scalaVersion212 = "2.12.4"
 
 lazy val specs2Version = "3.8.8"
-lazy val catsVersion = "1.0.0"
+lazy val catsVersion = "1.0.1"
 lazy val circeVersion = "0.9.0-M3"
 lazy val dispatchVersion = "0.11.3"
 lazy val startVaultTask = TaskKey[Unit](

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ lazy val scalaVersion211 = "2.11.11"
 lazy val scalaVersion212 = "2.12.4"
 
 lazy val specs2Version = "3.8.8"
-lazy val catsVersion = "1.0.0-RC1"
-lazy val circeVersion = "0.9.0-M2"
+lazy val catsVersion = "1.0.0"
+lazy val circeVersion = "0.9.0-M3"
 lazy val dispatchVersion = "0.11.3"
 lazy val startVaultTask = TaskKey[Unit](
   "startVaultTask",

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,12 @@ import sbt.Keys._
 
 name := "vault"
 
-lazy val uscalaVersion = "0.5.1"
+lazy val scalaVersion211 = "2.11.11"
+lazy val scalaVersion212 = "2.12.4"
+
 lazy val specs2Version = "3.8.8"
-lazy val circeVersion = "0.7.0"
+lazy val catsVersion = "1.0.0-RC1"
+lazy val circeVersion = "0.9.0-M2"
 lazy val dispatchVersion = "0.11.3"
 lazy val startVaultTask = TaskKey[Unit](
   "startVaultTask",
@@ -38,7 +41,8 @@ val pomInfo = (
 
 lazy val commonSettings = Seq(
   version := "0.4.2-SNAPSHOT",
-  scalaVersion := "2.11.11",
+  scalaVersion := scalaVersion211,
+  crossScalaVersions := Seq(scalaVersion211, scalaVersion212),
   organization := "janstenpickle.vault",
   pomExtra := pomInfo,
   autoAPIMappings := true,
@@ -50,11 +54,9 @@ lazy val commonSettings = Seq(
     url("https://github.com/janstenpickle/scala-vault/blob/master/LICENSE")
   ),
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.jcenterRepo),
+  libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion,
   libraryDependencies ++= Seq(
     "net.databinder.dispatch" %% "dispatch-core" % dispatchVersion,
-    "org.uscala" %% "uscala-result" % uscalaVersion,
-    "org.uscala" %% "uscala-result-async" % uscalaVersion,
-    "org.uscala" %% "uscala-result-specs2" % uscalaVersion % "it,test",
     "org.specs2" %% "specs2-core" % specs2Version % "it,test",
     "org.specs2" %% "specs2-scalacheck" % specs2Version % "it,test",
     "org.specs2" %% "specs2-junit" % specs2Version % "it,test"
@@ -77,7 +79,9 @@ lazy val commonSettings = Seq(
     "-unchecked",
     "-deprecation",
     "-feature",
-    "-language:implicitConversions"),
+    "-language:implicitConversions",
+    "-Ypartial-unification"
+  ),
   javacOptions in Compile ++= Seq(
     "-source", "1.8",
     "-target", "1.8",

--- a/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
@@ -1,84 +1,85 @@
-//package janstenpickle.vault.core
-//
-//import org.scalacheck.Prop
-//import org.specs2.ScalaCheck
-//
-//class GenericIT extends SecretsTests {
-//  override def backend: String = "secret"
-//}
-//
-//class CubbyHoleIT extends SecretsTests {
-//  override def backend: String = "cubbyhole"
-//}
-//
-//trait SecretsTests extends VaultSpec with ScalaCheck {
-//  import VaultSpec._
-//
-//  override def is =
-//    s2"""
-//      Can set a secret in vault $set
-//      Can set and get a secret in vault $get
-//      Can list keys $list
-//      Can set multiple subkeys $setMulti
-//      Can set and get multiple subKeys $getSetMulti
-//      Cannot get non-existent key $failGet
-//      Fails to perform actions on a non-vault server $failSetBadServer
-//      Fails to perform actions with a bad token $failSetBadToken
-//      """
-//
-//  def backend: String
-//
-//  lazy val good = Secrets(config, backend)
-//  lazy val badToken = Secrets(badTokenConfig, backend)
-//  lazy val badServer = Secrets(badServerConfig, backend)
-//
-//  def set = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
-//    good.set(key, value).attemptRun(_.getMessage()) must beOk
-//  }
-//
-//  def get = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
-//    (good.set(key, value).attemptRun(_.getMessage()) must beOk) and
-//    (good.get(key).attemptRun(_.getMessage()) must beOk.like {
-//      case a => a === value
-//    })
-//  }
-//
-//  def list = Prop.forAllNoShrink(strGen, strGen, strGen) { (key1, key2, value) =>
-//    (good.set(key1, value).attemptRun(_.getMessage()) must beOk) and
-//    (good.set(key2, value).attemptRun(_.getMessage()) must beOk) and
-//    (good.list.attemptRun(_.getMessage()) must beOk[List[String]].like {
-//      case a => a must containAllOf(Seq(key1, key2))
-//    })
-//  }
-//
-//  def setMulti = Prop.forAllNoShrink(strGen, strGen, strGen, strGen) {
-//    (key1, key2, value1, value2) =>
-//    good.set(
-//      "nicolas-cage",
-//      Map(key1 -> value1, key2 -> value2)
-//    ).attemptRun(_.getMessage()) must beOk
-//  }
-//
-//  def getSetMulti = Prop.forAllNoShrink(
-//    strGen, strGen, strGen, strGen, strGen
-//  ) { (key1, key2, value1, value2, mainKey) =>
-//    val testData = Map(key1 -> value1, key2 -> value2)
-//    (good.set(mainKey, testData).attemptRun(_.getMessage()) must beOk) and
-//    (good.getAll(mainKey).attemptRun(_.getMessage()) must beOk.like {
-//      case a => a === testData
-//    })
-//  }
-//
-//  def failGet = good.get("john").attemptRun(_.getMessage()) must beFail.
-//    like { case err =>
-//      err must contain("Received failure response from server: 404")
-//    }
-//
-//  def failSetBadServer = badServer.set(
-//    "nic", "cage"
-//  ).attemptRun(_.getMessage()) must beFail
-//
-//  def failSetBadToken = badToken.set(
-//    "nic", "cage"
-//  ).attemptRun(_.getMessage()) must beFail
-//}
+package janstenpickle.vault.core
+
+import janstenpickle.scala.result._
+import org.scalacheck.Prop
+import org.specs2.ScalaCheck
+
+class GenericIT extends SecretsTests {
+  override def backend: String = "secret"
+}
+
+class CubbyHoleIT extends SecretsTests {
+  override def backend: String = "cubbyhole"
+}
+
+trait SecretsTests extends VaultSpec with ScalaCheck {
+  import VaultSpec._
+
+  override def is =
+    s2"""
+      Can set a secret in vault $set
+      Can set and get a secret in vault $get
+      Can list keys $list
+      Can set multiple subkeys $setMulti
+      Can set and get multiple subKeys $getSetMulti
+      Cannot get non-existent key $failGet
+      Fails to perform actions on a non-vault server $failSetBadServer
+      Fails to perform actions with a bad token $failSetBadToken
+      """
+
+  def backend: String
+
+  lazy val good = Secrets(config, backend)
+  lazy val badToken = Secrets(badTokenConfig, backend)
+  lazy val badServer = Secrets(badServerConfig, backend)
+
+  def set = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
+    good.set(key, value).attemptRun must beRight
+  }
+
+  def get = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
+    (good.set(key, value).attemptRun must beRight) and
+    (good.get(key).attemptRun must beRight.like {
+      case a => a === value
+    })
+  }
+
+  def list = Prop.forAllNoShrink(strGen, strGen, strGen) { (key1, key2, value) =>
+    (good.set(key1, value).attemptRun must beRight) and
+    (good.set(key2, value).attemptRun must beRight) and
+    (good.list.attemptRun must beRight[List[String]].like {
+      case a => a must containAllOf(Seq(key1, key2))
+    })
+  }
+
+  def setMulti = Prop.forAllNoShrink(strGen, strGen, strGen, strGen) {
+    (key1, key2, value1, value2) =>
+    good.set(
+      "nicolas-cage",
+      Map(key1 -> value1, key2 -> value2)
+    ).attemptRun must beRight
+  }
+
+  def getSetMulti = Prop.forAllNoShrink(
+    strGen, strGen, strGen, strGen, strGen
+  ) { (key1, key2, value1, value2, mainKey) =>
+    val testData = Map(key1 -> value1, key2 -> value2)
+    (good.set(mainKey, testData).attemptRun must beRight) and
+    (good.getAll(mainKey).attemptRun must beRight.like {
+      case a => a === testData
+    })
+  }
+
+  def failGet = good.get("john").attemptRun must beLeft.
+    like { case err =>
+      err must contain("Received failure response from server: 404")
+    }
+
+  def failSetBadServer = badServer.set(
+    "nic", "cage"
+  ).attemptRun must beLeft
+
+  def failSetBadToken = badToken.set(
+    "nic", "cage"
+  ).attemptRun must beLeft
+}

--- a/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
@@ -1,84 +1,84 @@
-package janstenpickle.vault.core
-
-import org.scalacheck.Prop
-import org.specs2.ScalaCheck
-
-class GenericIT extends SecretsTests {
-  override def backend: String = "secret"
-}
-
-class CubbyHoleIT extends SecretsTests {
-  override def backend: String = "cubbyhole"
-}
-
-trait SecretsTests extends VaultSpec with ScalaCheck {
-  import VaultSpec._
-
-  override def is =
-    s2"""
-      Can set a secret in vault $set
-      Can set and get a secret in vault $get
-      Can list keys $list
-      Can set multiple subkeys $setMulti
-      Can set and get multiple subKeys $getSetMulti
-      Cannot get non-existent key $failGet
-      Fails to perform actions on a non-vault server $failSetBadServer
-      Fails to perform actions with a bad token $failSetBadToken
-      """
-
-  def backend: String
-
-  lazy val good = Secrets(config, backend)
-  lazy val badToken = Secrets(badTokenConfig, backend)
-  lazy val badServer = Secrets(badServerConfig, backend)
-
-  def set = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
-    good.set(key, value).attemptRun(_.getMessage()) must beOk
-  }
-
-  def get = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
-    (good.set(key, value).attemptRun(_.getMessage()) must beOk) and
-    (good.get(key).attemptRun(_.getMessage()) must beOk.like {
-      case a => a === value
-    })
-  }
-
-  def list = Prop.forAllNoShrink(strGen, strGen, strGen) { (key1, key2, value) =>
-    (good.set(key1, value).attemptRun(_.getMessage()) must beOk) and
-    (good.set(key2, value).attemptRun(_.getMessage()) must beOk) and
-    (good.list.attemptRun(_.getMessage()) must beOk[List[String]].like {
-      case a => a must containAllOf(Seq(key1, key2))
-    })
-  }
-
-  def setMulti = Prop.forAllNoShrink(strGen, strGen, strGen, strGen) {
-    (key1, key2, value1, value2) =>
-    good.set(
-      "nicolas-cage",
-      Map(key1 -> value1, key2 -> value2)
-    ).attemptRun(_.getMessage()) must beOk
-  }
-
-  def getSetMulti = Prop.forAllNoShrink(
-    strGen, strGen, strGen, strGen, strGen
-  ) { (key1, key2, value1, value2, mainKey) =>
-    val testData = Map(key1 -> value1, key2 -> value2)
-    (good.set(mainKey, testData).attemptRun(_.getMessage()) must beOk) and
-    (good.getAll(mainKey).attemptRun(_.getMessage()) must beOk.like {
-      case a => a === testData
-    })
-  }
-
-  def failGet = good.get("john").attemptRun(_.getMessage()) must beFail.
-    like { case err =>
-      err must contain("Received failure response from server: 404")
-    }
-
-  def failSetBadServer = badServer.set(
-    "nic", "cage"
-  ).attemptRun(_.getMessage()) must beFail
-
-  def failSetBadToken = badToken.set(
-    "nic", "cage"
-  ).attemptRun(_.getMessage()) must beFail
-}
+//package janstenpickle.vault.core
+//
+//import org.scalacheck.Prop
+//import org.specs2.ScalaCheck
+//
+//class GenericIT extends SecretsTests {
+//  override def backend: String = "secret"
+//}
+//
+//class CubbyHoleIT extends SecretsTests {
+//  override def backend: String = "cubbyhole"
+//}
+//
+//trait SecretsTests extends VaultSpec with ScalaCheck {
+//  import VaultSpec._
+//
+//  override def is =
+//    s2"""
+//      Can set a secret in vault $set
+//      Can set and get a secret in vault $get
+//      Can list keys $list
+//      Can set multiple subkeys $setMulti
+//      Can set and get multiple subKeys $getSetMulti
+//      Cannot get non-existent key $failGet
+//      Fails to perform actions on a non-vault server $failSetBadServer
+//      Fails to perform actions with a bad token $failSetBadToken
+//      """
+//
+//  def backend: String
+//
+//  lazy val good = Secrets(config, backend)
+//  lazy val badToken = Secrets(badTokenConfig, backend)
+//  lazy val badServer = Secrets(badServerConfig, backend)
+//
+//  def set = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
+//    good.set(key, value).attemptRun(_.getMessage()) must beOk
+//  }
+//
+//  def get = Prop.forAllNoShrink(strGen, strGen) { (key, value) =>
+//    (good.set(key, value).attemptRun(_.getMessage()) must beOk) and
+//    (good.get(key).attemptRun(_.getMessage()) must beOk.like {
+//      case a => a === value
+//    })
+//  }
+//
+//  def list = Prop.forAllNoShrink(strGen, strGen, strGen) { (key1, key2, value) =>
+//    (good.set(key1, value).attemptRun(_.getMessage()) must beOk) and
+//    (good.set(key2, value).attemptRun(_.getMessage()) must beOk) and
+//    (good.list.attemptRun(_.getMessage()) must beOk[List[String]].like {
+//      case a => a must containAllOf(Seq(key1, key2))
+//    })
+//  }
+//
+//  def setMulti = Prop.forAllNoShrink(strGen, strGen, strGen, strGen) {
+//    (key1, key2, value1, value2) =>
+//    good.set(
+//      "nicolas-cage",
+//      Map(key1 -> value1, key2 -> value2)
+//    ).attemptRun(_.getMessage()) must beOk
+//  }
+//
+//  def getSetMulti = Prop.forAllNoShrink(
+//    strGen, strGen, strGen, strGen, strGen
+//  ) { (key1, key2, value1, value2, mainKey) =>
+//    val testData = Map(key1 -> value1, key2 -> value2)
+//    (good.set(mainKey, testData).attemptRun(_.getMessage()) must beOk) and
+//    (good.getAll(mainKey).attemptRun(_.getMessage()) must beOk.like {
+//      case a => a === testData
+//    })
+//  }
+//
+//  def failGet = good.get("john").attemptRun(_.getMessage()) must beFail.
+//    like { case err =>
+//      err must contain("Received failure response from server: 404")
+//    }
+//
+//  def failSetBadServer = badServer.set(
+//    "nic", "cage"
+//  ).attemptRun(_.getMessage()) must beFail
+//
+//  def failSetBadToken = badToken.set(
+//    "nic", "cage"
+//  ).attemptRun(_.getMessage()) must beFail
+//}

--- a/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/SecretsIT.scala
@@ -1,5 +1,6 @@
 package janstenpickle.vault.core
 
+import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.result._
 import org.scalacheck.Prop
 import org.specs2.ScalaCheck

--- a/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
@@ -1,52 +1,54 @@
-//package janstenpickle.vault.core
-//
-//import java.net.URL
-//
-//import janstenpickle.scala.syntax.SyntaxRequest._
-//import janstenpickle.scala.syntax.ResponseSyntax._
-//import janstenpickle.scala.syntax.VaultConfigSyntax._
-//import org.scalacheck.Gen
-//import org.specs2.Specification
-//import org.specs2.specification.core.Fragments
-//
-//import scala.concurrent.ExecutionContext
-//import scala.io.Source
-//
-//
-//trait VaultSpec extends Specification with ResultMatchers {
-//  implicit val errConverter: Throwable => String = _.getMessage
-//  implicit val ec: ExecutionContext = ExecutionContext.global
-//
-//  lazy val rootToken = Source.fromFile("/tmp/.root-token").mkString.trim
-//  lazy val roleId = Source.fromFile("/tmp/.role-id").mkString.trim
-//  lazy val secretId = Source.fromFile("/tmp/.secret-id").mkString.trim
-//
-//  lazy val rootConfig: VaultConfig = VaultConfig(
-//    WSClient(new URL("http://localhost:8200")), rootToken
-//  )
-//  lazy val badTokenConfig = VaultConfig(
-//    rootConfig.wsClient,
-//    "face-off"
-//  )
-//  lazy val config = VaultConfig(
-//    rootConfig.wsClient,
-//    AppRole(roleId, secretId)
-//  )
-//  lazy val badServerConfig = VaultConfig(
-//    WSClient(new URL("http://nic-cage.xyz")),
-//    "con-air"
-//  )
-//
-////  def check = config.token.attemptRun(_.getMessage) must beOk
-//
-//  override def map(fs: => Fragments) =
-////    s2"""
-////      Can receive a token for an AppRole $check
-////    """ ^
-//    fs
-//}
-//
-//object VaultSpec {
-//  val longerStrGen = Gen.alphaStr.suchThat(_.length >= 3)
-//  val strGen = Gen.alphaStr.suchThat(_.nonEmpty)
-//}
+package janstenpickle.vault.core
+
+import java.net.URL
+
+import janstenpickle.scala.result._
+import janstenpickle.scala.syntax.SyntaxRequest._
+import janstenpickle.scala.syntax.ResponseSyntax._
+import janstenpickle.scala.syntax.VaultConfigSyntax._
+import org.scalacheck.Gen
+import org.specs2.Specification
+import org.specs2.matcher.EitherMatchers
+import org.specs2.specification.core.Fragments
+
+import scala.concurrent.ExecutionContext
+import scala.io.Source
+
+
+trait VaultSpec extends Specification with EitherMatchers {
+  implicit val errConverter: Throwable => String = _.getMessage
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  lazy val rootToken: String = Source.fromFile("/tmp/.root-token").mkString.trim
+  lazy val roleId:    String = Source.fromFile("/tmp/.role-id").mkString.trim
+  lazy val secretId:  String = Source.fromFile("/tmp/.secret-id").mkString.trim
+
+  lazy val rootConfig: VaultConfig = VaultConfig(
+    WSClient(new URL("http://localhost:8200")), rootToken
+  )
+  lazy val badTokenConfig = VaultConfig(
+    rootConfig.wsClient,
+    "face-off"
+  )
+  lazy val config = VaultConfig(
+    rootConfig.wsClient,
+    AppRole(roleId, secretId)
+  )
+  lazy val badServerConfig = VaultConfig(
+    WSClient(new URL("http://nic-cage.xyz")),
+    "con-air"
+  )
+
+  def check = config.token.attemptRun should beRight
+
+  override def map(fs: => Fragments) =
+    s2"""
+      Can receive a token for an AppRole $check
+    """ ^
+    fs
+}
+
+object VaultSpec {
+  val longerStrGen = Gen.alphaStr.suchThat(_.length >= 3)
+  val strGen = Gen.alphaStr.suchThat(_.nonEmpty)
+}

--- a/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
@@ -1,52 +1,52 @@
-package janstenpickle.vault.core
-
-import java.net.URL
-
-import janstenpickle.scala.syntax.SyntaxRequest._
-import janstenpickle.scala.syntax.ResponseSyntax._
-import janstenpickle.scala.syntax.VaultConfigSyntax._
-import org.scalacheck.Gen
-import org.specs2.Specification
-import org.specs2.specification.core.Fragments
-
-import scala.concurrent.ExecutionContext
-import scala.io.Source
-
-
-trait VaultSpec extends Specification with ResultMatchers {
-  implicit val errConverter: Throwable => String = _.getMessage
-  implicit val ec: ExecutionContext = ExecutionContext.global
-
-  lazy val rootToken = Source.fromFile("/tmp/.root-token").mkString.trim
-  lazy val roleId = Source.fromFile("/tmp/.role-id").mkString.trim
-  lazy val secretId = Source.fromFile("/tmp/.secret-id").mkString.trim
-
-  lazy val rootConfig: VaultConfig = VaultConfig(
-    WSClient(new URL("http://localhost:8200")), rootToken
-  )
-  lazy val badTokenConfig = VaultConfig(
-    rootConfig.wsClient,
-    "face-off"
-  )
-  lazy val config = VaultConfig(
-    rootConfig.wsClient,
-    AppRole(roleId, secretId)
-  )
-  lazy val badServerConfig = VaultConfig(
-    WSClient(new URL("http://nic-cage.xyz")),
-    "con-air"
-  )
-
-//  def check = config.token.attemptRun(_.getMessage) must beOk
-
-  override def map(fs: => Fragments) =
-//    s2"""
-//      Can receive a token for an AppRole $check
-//    """ ^
-    fs
-}
-
-object VaultSpec {
-  val longerStrGen = Gen.alphaStr.suchThat(_.length >= 3)
-  val strGen = Gen.alphaStr.suchThat(_.nonEmpty)
-}
+//package janstenpickle.vault.core
+//
+//import java.net.URL
+//
+//import janstenpickle.scala.syntax.SyntaxRequest._
+//import janstenpickle.scala.syntax.ResponseSyntax._
+//import janstenpickle.scala.syntax.VaultConfigSyntax._
+//import org.scalacheck.Gen
+//import org.specs2.Specification
+//import org.specs2.specification.core.Fragments
+//
+//import scala.concurrent.ExecutionContext
+//import scala.io.Source
+//
+//
+//trait VaultSpec extends Specification with ResultMatchers {
+//  implicit val errConverter: Throwable => String = _.getMessage
+//  implicit val ec: ExecutionContext = ExecutionContext.global
+//
+//  lazy val rootToken = Source.fromFile("/tmp/.root-token").mkString.trim
+//  lazy val roleId = Source.fromFile("/tmp/.role-id").mkString.trim
+//  lazy val secretId = Source.fromFile("/tmp/.secret-id").mkString.trim
+//
+//  lazy val rootConfig: VaultConfig = VaultConfig(
+//    WSClient(new URL("http://localhost:8200")), rootToken
+//  )
+//  lazy val badTokenConfig = VaultConfig(
+//    rootConfig.wsClient,
+//    "face-off"
+//  )
+//  lazy val config = VaultConfig(
+//    rootConfig.wsClient,
+//    AppRole(roleId, secretId)
+//  )
+//  lazy val badServerConfig = VaultConfig(
+//    WSClient(new URL("http://nic-cage.xyz")),
+//    "con-air"
+//  )
+//
+////  def check = config.token.attemptRun(_.getMessage) must beOk
+//
+//  override def map(fs: => Fragments) =
+////    s2"""
+////      Can receive a token for an AppRole $check
+////    """ ^
+//    fs
+//}
+//
+//object VaultSpec {
+//  val longerStrGen = Gen.alphaStr.suchThat(_.length >= 3)
+//  val strGen = Gen.alphaStr.suchThat(_.nonEmpty)
+//}

--- a/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
@@ -3,6 +3,7 @@ package janstenpickle.vault.core
 import java.net.URL
 
 import janstenpickle.scala.result._
+import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._

--- a/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
+++ b/core/src/it/scala/janstenpickle/vault/core/VaultSpec.scala
@@ -8,7 +8,6 @@ import janstenpickle.scala.syntax.VaultConfigSyntax._
 import org.scalacheck.Gen
 import org.specs2.Specification
 import org.specs2.specification.core.Fragments
-import uscala.result.specs2.ResultMatchers
 
 import scala.concurrent.ExecutionContext
 import scala.io.Source
@@ -38,12 +37,12 @@ trait VaultSpec extends Specification with ResultMatchers {
     "con-air"
   )
 
-  def check = config.token.attemptRun(_.getMessage) must beOk
+//  def check = config.token.attemptRun(_.getMessage) must beOk
 
   override def map(fs: => Fragments) =
-    s2"""
-      Can receive a token for an AppRole $check
-    """ ^
+//    s2"""
+//      Can receive a token for an AppRole $check
+//    """ ^
     fs
 }
 

--- a/core/src/main/scala/janstenpickle/scala/Result.scala
+++ b/core/src/main/scala/janstenpickle/scala/Result.scala
@@ -1,0 +1,36 @@
+package janstenpickle.scala
+
+import cats.data.EitherT
+
+import scala.concurrent.{ExecutionContext, Future}
+import cats.implicits._
+
+object Result {
+  type Result[F, R] = Either[F, R]
+
+  def pure[F, R](r: R): Either[F, R] = Either right r
+
+  def fail[F, R](f: F): Either[F, R] = Either left f
+
+  type AsyncResult[F, R] = Future[Result[F, R]]
+
+  type AsyncEitherT[F, R] = cats.data.EitherT[Future, F, R]
+
+  object AsyncResult {
+    def pure[F, R](r: R): AsyncResult[F, R] = {
+      Future.successful(Either right r)
+    }
+  }
+
+  implicit class AsyncResultOps[F, R](f: AsyncResult[F, R]) {
+    def eiT: AsyncEitherT[F, R] = EitherT[Future, F, R](f)
+  }
+
+  implicit class AsyncResultOpsEitherT[F, R](f: Either[F, R]) {
+    def eiT(implicit ec: ExecutionContext): AsyncEitherT[F, R] = EitherT.fromEither[Future](f)
+  }
+
+  implicit class AsyncResultOpsAny[F, R](r: R) {
+    def eiT: AsyncEitherT[F, R] = EitherT.apply(Future.successful(pure(r)))
+  }
+}

--- a/core/src/main/scala/janstenpickle/scala/result/package.scala
+++ b/core/src/main/scala/janstenpickle/scala/result/package.scala
@@ -1,7 +1,5 @@
 package janstenpickle.scala
 
-import cats.data.EitherT
-
 import scala.concurrent.Future
 import cats.implicits._
 

--- a/core/src/main/scala/janstenpickle/scala/result/package.scala
+++ b/core/src/main/scala/janstenpickle/scala/result/package.scala
@@ -2,10 +2,10 @@ package janstenpickle.scala
 
 import cats.data.EitherT
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.Future
 import cats.implicits._
 
-import scala.concurrent.duration._
+
 import scala.language.postfixOps
 
 package object result {
@@ -18,7 +18,6 @@ package object result {
     def fail[F, R](f: F): Either[F, R] = Either left f
   }
 
-
   type AsyncResult[F, R] = Future[Result[F, R]]
 
   type AsyncEitherT[F, R] = cats.data.EitherT[Future, F, R]
@@ -29,20 +28,5 @@ package object result {
     }
   }
 
-  implicit class AsyncResultOps[F, R](f: AsyncResult[F, R]) {
-    def eiT: AsyncEitherT[F, R] = EitherT[Future, F, R](f)
 
-    def attemptRun(implicit ec: ExecutionContext): Result[F, R] =
-      Await.result(f, 1 minute)
-  }
-
-  implicit class AsyncResultOpsEitherT[F, R](f: Either[F, R]) {
-    def eiT(implicit ec: ExecutionContext): AsyncEitherT[F, R] =
-      EitherT.fromEither[Future](f)
-  }
-
-  implicit class AsyncResultOpsAny[F, R](r: R) {
-    def eiT: AsyncEitherT[F, R] =
-      EitherT.apply(Future.successful(Either right r))
-  }
 }

--- a/core/src/main/scala/janstenpickle/scala/result/package.scala
+++ b/core/src/main/scala/janstenpickle/scala/result/package.scala
@@ -7,21 +7,21 @@ import cats.implicits._
 import scala.language.postfixOps
 
 package object result {
-  type Result[F, R] = Either[F, R]
+  type Result[R] = Either[String, R]
   val Result: Either.type = Either
 
   implicit class ResultCompanionOps(dc: Either.type ){
-    def pure[F, R](r: R): Either[F, R] = Either right r
+    def pure[R](r: R): Either[String, R] = Either right r
 
-    def fail[F, R](f: F): Either[F, R] = Either left f
+    def fail[R](f: String): Either[String, R] = Either left f
   }
 
-  type AsyncResult[F, R] = Future[Result[F, R]]
+  type AsyncResult[R] = Future[Result[R]]
 
-  type AsyncEitherT[F, R] = cats.data.EitherT[Future, F, R]
+  type AsyncEitherT[R] = cats.data.EitherT[Future, String, R]
 
   object AsyncResult {
-    def pure[F, R](r: R): AsyncResult[F, R] = {
+    def pure[R](r: R): AsyncResult[R] = {
       Future.successful(Either right r)
     }
   }

--- a/core/src/main/scala/janstenpickle/scala/result/package.scala
+++ b/core/src/main/scala/janstenpickle/scala/result/package.scala
@@ -5,12 +5,16 @@ import cats.data.EitherT
 import scala.concurrent.{ExecutionContext, Future}
 import cats.implicits._
 
-object Result {
+package object result {
   type Result[F, R] = Either[F, R]
+  val Result: Either.type = Either
 
-  def pure[F, R](r: R): Either[F, R] = Either right r
+  implicit class ResultCompanionOps(dc: Either.type ){
+    def pure[F, R](r: R): Either[F, R] = Either right r
 
-  def fail[F, R](f: F): Either[F, R] = Either left f
+    def fail[F, R](f: F): Either[F, R] = Either left f
+  }
+
 
   type AsyncResult[F, R] = Future[Result[F, R]]
 
@@ -31,6 +35,6 @@ object Result {
   }
 
   implicit class AsyncResultOpsAny[F, R](r: R) {
-    def eiT: AsyncEitherT[F, R] = EitherT.apply(Future.successful(pure(r)))
+    def eiT: AsyncEitherT[F, R] = EitherT.apply(Future.successful(Either right r))
   }
 }

--- a/core/src/main/scala/janstenpickle/scala/syntax/syntax.scala
+++ b/core/src/main/scala/janstenpickle/scala/syntax/syntax.scala
@@ -21,6 +21,7 @@ object OptionSyntax {
 }
 
 object AsyncResultSyntax {
+
   implicit class FutureToAsyncResult[T](future: Future[T])
   (implicit ec: ExecutionContext) {
     def toAsyncResult: AsyncResult[String, T] = {

--- a/core/src/main/scala/janstenpickle/scala/syntax/syntax.scala
+++ b/core/src/main/scala/janstenpickle/scala/syntax/syntax.scala
@@ -6,7 +6,7 @@ import io.circe._
 import io.circe.parser._
 import io.circe.syntax._
 import janstenpickle.vault.core.VaultConfig
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
 // scalastyle:off magic.number
 case class Secrets(config: VaultConfig, backend: String) {
   def get(key: String, subKey: String = "value")
-  (implicit ec: ExecutionContext): AsyncResult[String, String] = {
+  (implicit ec: ExecutionContext): AsyncResult[String] = {
     val r = for {
       x <- getAll(key).eiT
       r <- Either.fromOption(
@@ -26,27 +26,27 @@ case class Secrets(config: VaultConfig, backend: String) {
 
 
   def getAll(key: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Map[String, String]] =
+  (implicit ec: ExecutionContext): AsyncResult[Map[String, String]] =
     config.authenticatedRequest(path(key))(_.get).
       execute.
       acceptStatusCodes(200).
       extractFromJson[Map[String, String]](_.downField("data"))
 
   def set(key: String, value: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     set(key, "value", value)
 
   def set(key: String, subKey: String, value: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     set(key, Map(subKey -> value))
 
   def set(key: String, values: Map[String, String])
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(path(key))(_.post(values)).
       execute.
       acceptStatusCodes(204)
 
-  def list(implicit ec: ExecutionContext): AsyncResult[String, List[String]] =
+  def list(implicit ec: ExecutionContext): AsyncResult[List[String]] =
     config.authenticatedRequest(backend)(
       _.addQueryParameter("list", true.toString).get).
       execute.

--- a/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
@@ -1,6 +1,7 @@
 package janstenpickle.vault.core
 
 import com.ning.http.client.Response
+import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._

--- a/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/Secrets.scala
@@ -4,7 +4,7 @@ import com.ning.http.client.Response
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 import cats.implicits._
 
 import scala.concurrent.ExecutionContext

--- a/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
@@ -12,7 +12,7 @@ import janstenpickle.scala.result._
 
 import scala.concurrent.ExecutionContext
 
-case class VaultConfig(wsClient: WSClient, token: AsyncResult[String, String])
+case class VaultConfig(wsClient: WSClient, token: AsyncResult[String])
 @deprecated("Vault 0.6.5 deprecated AppId in favor of AppRole", "0.4.0")
 case class AppId(app_id: String, user_id: String)
 case class AppRole(role_id: String, secret_id: String)
@@ -55,8 +55,10 @@ object VaultConfig {
 
 
 
-case class WSClient(server: URL,
-                    version: String = "v1") {
+case class WSClient(
+  server: URL,
+  version: String = "v1"
+) {
    def path(p: String): Req =
      url(s"${server.toString}/$version/$p").
        setContentType("application/json", "UTF-8")

--- a/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 
 import scala.concurrent.ExecutionContext
 

--- a/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
+++ b/core/src/main/scala/janstenpickle/vault/core/VaultConfig.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import janstenpickle.scala.syntax.AsyncResultSyntax._
 import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
-import uscala.concurrent.result.AsyncResult
+import janstenpickle.scala.Result._
 
 import scala.concurrent.ExecutionContext
 
@@ -50,7 +50,7 @@ object VaultConfig {
 
   def apply(wsClient: WSClient, token: String)
   (implicit ec: ExecutionContext): VaultConfig =
-    VaultConfig(wsClient, AsyncResult.ok[String, String](token))
+    VaultConfig(wsClient, AsyncResult.pure(token))
 }
 
 

--- a/manage/src/it/scala/janstenpickle/vault/manage/AuthIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/AuthIT.scala
@@ -1,38 +1,38 @@
-package janstenpickle.vault.manage
-
-import janstenpickle.vault.core.VaultSpec
-import org.scalacheck.{Prop, Gen}
-import org.specs2.ScalaCheck
-
-class AuthIT extends VaultSpec with ScalaCheck {
-  import AuthIT._
-  import VaultSpec._
-
-  def is =
-    s2"""
-      Can enable and disable valid auth mount $happy
-      Cannot enable an invalid auth type $enableFail
-    """
-
-  lazy val underTest = new Auth(config)
-
-  def happy = Prop.forAllNoShrink(
-    backends, longerStrGen, Gen.option(longerStrGen))((backend, mount, desc) =>
-      (underTest.enable(backend, Some(mount), desc)
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.disable(mount).attemptRun(_.getMessage()) must beOk)
-  )
-
-  def enableFail = Prop.forAllNoShrink(
-    longerStrGen.suchThat(!backendNames.contains(_)),
-    longerStrGen,
-    Gen.option(longerStrGen))((backend, mount, desc) =>
-      underTest.enable(mount).attemptRun(_.getMessage()) must beFail
-  )
-
-}
-
-object AuthIT {
-  val backendNames = List("github", "app-id", "ldap", "userpass")
-  val backends = Gen.oneOf(backendNames)
-}
+//package janstenpickle.vault.manage
+//
+//import janstenpickle.vault.core.VaultSpec
+//import org.scalacheck.{Prop, Gen}
+//import org.specs2.ScalaCheck
+//
+//class AuthIT extends VaultSpec with ScalaCheck {
+//  import AuthIT._
+//  import VaultSpec._
+//
+//  def is =
+//    s2"""
+//      Can enable and disable valid auth mount $happy
+//      Cannot enable an invalid auth type $enableFail
+//    """
+//
+//  lazy val underTest = new Auth(config)
+//
+//  def happy = Prop.forAllNoShrink(
+//    backends, longerStrGen, Gen.option(longerStrGen))((backend, mount, desc) =>
+//      (underTest.enable(backend, Some(mount), desc)
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.disable(mount).attemptRun(_.getMessage()) must beOk)
+//  )
+//
+//  def enableFail = Prop.forAllNoShrink(
+//    longerStrGen.suchThat(!backendNames.contains(_)),
+//    longerStrGen,
+//    Gen.option(longerStrGen))((backend, mount, desc) =>
+//      underTest.enable(mount).attemptRun(_.getMessage()) must beFail
+//  )
+//
+//}
+//
+//object AuthIT {
+//  val backendNames = List("github", "app-id", "ldap", "userpass")
+//  val backends = Gen.oneOf(backendNames)
+//}

--- a/manage/src/it/scala/janstenpickle/vault/manage/AuthIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/AuthIT.scala
@@ -1,38 +1,39 @@
-//package janstenpickle.vault.manage
-//
-//import janstenpickle.vault.core.VaultSpec
-//import org.scalacheck.{Prop, Gen}
-//import org.specs2.ScalaCheck
-//
-//class AuthIT extends VaultSpec with ScalaCheck {
-//  import AuthIT._
-//  import VaultSpec._
-//
-//  def is =
-//    s2"""
-//      Can enable and disable valid auth mount $happy
-//      Cannot enable an invalid auth type $enableFail
-//    """
-//
-//  lazy val underTest = new Auth(config)
-//
-//  def happy = Prop.forAllNoShrink(
-//    backends, longerStrGen, Gen.option(longerStrGen))((backend, mount, desc) =>
-//      (underTest.enable(backend, Some(mount), desc)
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.disable(mount).attemptRun(_.getMessage()) must beOk)
-//  )
-//
-//  def enableFail = Prop.forAllNoShrink(
-//    longerStrGen.suchThat(!backendNames.contains(_)),
-//    longerStrGen,
-//    Gen.option(longerStrGen))((backend, mount, desc) =>
-//      underTest.enable(mount).attemptRun(_.getMessage()) must beFail
-//  )
-//
-//}
-//
-//object AuthIT {
-//  val backendNames = List("github", "app-id", "ldap", "userpass")
-//  val backends = Gen.oneOf(backendNames)
-//}
+package janstenpickle.vault.manage
+
+import janstenpickle.scala.syntax.AsyncResultSyntax._
+import janstenpickle.vault.core.VaultSpec
+import org.scalacheck.{Prop, Gen}
+import org.specs2.ScalaCheck
+
+class AuthIT extends VaultSpec with ScalaCheck {
+  import AuthIT._
+  import VaultSpec._
+
+  def is =
+    s2"""
+      Can enable and disable valid auth mount $happy
+      Cannot enable an invalid auth type $enableFail
+    """
+
+  lazy val underTest = new Auth(config)
+
+  def happy = Prop.forAllNoShrink(
+    backends, longerStrGen, Gen.option(longerStrGen))((backend, mount, desc) =>
+      (underTest.enable(backend, Some(mount), desc)
+      .attemptRun must beRight) and
+      (underTest.disable(mount).attemptRun must beRight)
+  )
+
+  def enableFail = Prop.forAllNoShrink(
+    longerStrGen.suchThat(!backendNames.contains(_)),
+    longerStrGen,
+    Gen.option(longerStrGen))((backend, mount, desc) =>
+      underTest.enable(mount).attemptRun must beLeft
+  )
+
+}
+
+object AuthIT {
+  val backendNames = List("github", "app-id", "ldap", "userpass")
+  val backends = Gen.oneOf(backendNames)
+}

--- a/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
@@ -1,83 +1,87 @@
-//package janstenpickle.vault.manage
-//
-//import com.ning.http.client.Response
-//import com.ning.http.client.providers.jdk.JDKResponse
-//import janstenpickle.vault.core.VaultSpec
-//import janstenpickle.vault.manage.Model.{Mount, MountConfig}
-//import org.scalacheck.{Gen, Prop}
-//import org.specs2.ScalaCheck
-//import janstenpickle.scala.Result
-//
-//class MountIT extends VaultSpec with ScalaCheck {
-//  import MountIT._
-//  import VaultSpec._
-//
-//  def is =
-//    s2"""
-//      Can enable, remount and disable a valid mount $happy
-//      Can enable, list and then disable valid mounts $listSuccess
-//      Cannot enable an invalid mount type $enableFail
-//    """
-//
-//  lazy val underTest = new Mounts(config)
-//
-//  def happy = Prop.forAllNoShrink(
-//    mountGen,
-//    longerStrGen,
-//    longerStrGen,
-//    Gen.option(longerStrGen))((mount, mountPoint, remountPoint, desc) => {
-//      (underTest.mount(mount.`type`, Some(mountPoint), desc, Some(mount))
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.remount(mountPoint, remountPoint)
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.delete(remountPoint)
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.delete(mountPoint)
-//      .attemptRun(_.getMessage()) must beOk)
-//    })
-//
-//  def listSuccess = (processMountTypes((acc, mount) =>
-//    acc.flatMap(_ => underTest.mount(mount)
-//    .attemptRun(_.getMessage()))) must beOk) and
-//    (underTest.list.attemptRun(_.getMessage()) must beOk.like {
-//      case a => a.map(_._2.`type`) must containAllOf(mountTypes)
-//    }) and
-//    (processMountTypes((acc, mount) =>
-//      acc.flatMap(_ =>
-//          underTest.delete(mount).attemptRun(_.getMessage()))
-//    ) must beOk)
-//
-//  def enableFail = Prop.forAllNoShrink(
-//    longerStrGen.suchThat(!mountTypes.contains(_)),
-//    longerStrGen,
-//    Gen.option(longerStrGen))((`type`, mount, desc) =>
-//      underTest.mount(`type`, Some(mount), desc)
-//        .attemptRun(_.getMessage()) must beFail
-//  )
-//
-//}
-//
-//object MountIT {
-//  import VaultSpec._
-//
-//  val mountTypes = List(
-//    "aws", "cassandra", "consul", "generic",
-//    "mssql", "mysql", "pki", "postgresql", "ssh", "transit"
-//  )
-//  val mount = Gen.oneOf(mountTypes)
-//  val mounts = Gen.listOf(mountTypes).suchThat(_.nonEmpty)
-//
-//  val mountGen = for {
-//    mountType <- mount
-//    description <- Gen.option(longerStrGen)
-//    defaultTtl <- Gen.option(Gen.posNum[Int])
-//    maxTtl <- Gen.option(Gen.posNum[Int])
-//    forceNoCache <- Gen.option(Gen.oneOf(true, false))
-//  } yield Mount(mountType, description, Some(MountConfig(defaultTtl, maxTtl, forceNoCache)))
-//
-//  def processMountTypes(op: (Result[String, Response], String) => Result[String,
-//    Response]) =
-//      mountTypes.foldLeft[Result[String, Response]](Result.ok(new
-//        JDKResponse(null, null, null)))(op)
-//
-//}
+package janstenpickle.vault.manage
+
+import com.ning.http.client.Response
+import com.ning.http.client.providers.jdk.JDKResponse
+import janstenpickle.vault.core.VaultSpec
+import janstenpickle.vault.manage.Model.{Mount, MountConfig}
+import org.scalacheck.{Gen, Prop}
+import org.specs2.ScalaCheck
+import janstenpickle.scala.syntax.AsyncResultSyntax._
+import janstenpickle.scala.result._
+
+class MountIT extends VaultSpec with ScalaCheck {
+  import MountIT._
+  import VaultSpec._
+
+  def is =
+    s2"""
+      Can enable, remount and disable a valid mount $happy
+      Can enable, list and then disable valid mounts $listSuccess
+      Cannot enable an invalid mount type $enableFail
+    """
+
+  lazy val underTest = new Mounts(config)
+
+  def happy = Prop.forAllNoShrink(
+    mountGen,
+    longerStrGen,
+    longerStrGen,
+    Gen.option(longerStrGen))((mount, mountPoint, remountPoint, desc) => {
+      (underTest.mount(mount.`type`, Some(mountPoint), desc, Some(mount))
+      .attemptRun must beRight) and
+      (underTest.remount(mountPoint, remountPoint)
+        .attemptRun must beRight) and
+      (underTest.delete(remountPoint)
+        .attemptRun must beRight) and
+      (underTest.delete(mountPoint)
+        .attemptRun must beRight)
+    })
+
+  def listSuccess = {
+    processMountTypes((acc, mount) =>
+      acc.right.flatMap(_ => underTest.mount(mount).attemptRun)
+    ) must beRight
+  } and {
+    underTest.list.attemptRun must beRight.like {
+      case a => a.map(_._2.`type`) must containAllOf(mountTypes)
+    }
+  } and {
+    processMountTypes((acc, mount) =>
+      acc.right.flatMap(_ => underTest.delete(mount).attemptRun)
+    ) must beRight
+  }
+
+  def enableFail = Prop.forAllNoShrink(
+    longerStrGen.suchThat(!mountTypes.contains(_)),
+    longerStrGen,
+    Gen.option(longerStrGen))((`type`, mount, desc) =>
+      underTest.mount(`type`, Some(mount), desc)
+        .attemptRun must beLeft
+  )
+
+}
+
+object MountIT {
+  import VaultSpec._
+
+  val mountTypes = List(
+    "aws", "cassandra", "consul", "generic",
+    "mssql", "mysql", "pki", "postgresql", "ssh", "transit"
+  )
+  val mount = Gen.oneOf(mountTypes)
+  val mounts = Gen.listOf(mountTypes).suchThat(_.nonEmpty)
+
+  val mountGen = for {
+    mountType <- mount
+    description <- Gen.option(longerStrGen)
+    defaultTtl <- Gen.option(Gen.posNum[Int])
+    maxTtl <- Gen.option(Gen.posNum[Int])
+    forceNoCache <- Gen.option(Gen.oneOf(true, false))
+  } yield Mount(mountType, description, Some(MountConfig(defaultTtl, maxTtl, forceNoCache)))
+
+  def processMountTypes(op: (Result[String, Response], String) => Result[String,
+    Response]) =
+      mountTypes.foldLeft[Result[String, Response]](Result.pure(new
+        JDKResponse(null, null, null)))(op)
+
+}

--- a/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
@@ -1,83 +1,83 @@
-package janstenpickle.vault.manage
-
-import com.ning.http.client.Response
-import com.ning.http.client.providers.jdk.JDKResponse
-import janstenpickle.vault.core.VaultSpec
-import janstenpickle.vault.manage.Model.{Mount, MountConfig}
-import org.scalacheck.{Gen, Prop}
-import org.specs2.ScalaCheck
-import uscala.result.Result
-
-class MountIT extends VaultSpec with ScalaCheck {
-  import MountIT._
-  import VaultSpec._
-
-  def is =
-    s2"""
-      Can enable, remount and disable a valid mount $happy
-      Can enable, list and then disable valid mounts $listSuccess
-      Cannot enable an invalid mount type $enableFail
-    """
-
-  lazy val underTest = new Mounts(config)
-
-  def happy = Prop.forAllNoShrink(
-    mountGen,
-    longerStrGen,
-    longerStrGen,
-    Gen.option(longerStrGen))((mount, mountPoint, remountPoint, desc) => {
-      (underTest.mount(mount.`type`, Some(mountPoint), desc, Some(mount))
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.remount(mountPoint, remountPoint)
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.delete(remountPoint)
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.delete(mountPoint)
-      .attemptRun(_.getMessage()) must beOk)
-    })
-
-  def listSuccess = (processMountTypes((acc, mount) =>
-    acc.flatMap(_ => underTest.mount(mount)
-    .attemptRun(_.getMessage()))) must beOk) and
-    (underTest.list.attemptRun(_.getMessage()) must beOk.like {
-      case a => a.map(_._2.`type`) must containAllOf(mountTypes)
-    }) and
-    (processMountTypes((acc, mount) =>
-      acc.flatMap(_ =>
-          underTest.delete(mount).attemptRun(_.getMessage()))
-    ) must beOk)
-
-  def enableFail = Prop.forAllNoShrink(
-    longerStrGen.suchThat(!mountTypes.contains(_)),
-    longerStrGen,
-    Gen.option(longerStrGen))((`type`, mount, desc) =>
-      underTest.mount(`type`, Some(mount), desc)
-        .attemptRun(_.getMessage()) must beFail
-  )
-
-}
-
-object MountIT {
-  import VaultSpec._
-
-  val mountTypes = List(
-    "aws", "cassandra", "consul", "generic",
-    "mssql", "mysql", "pki", "postgresql", "ssh", "transit"
-  )
-  val mount = Gen.oneOf(mountTypes)
-  val mounts = Gen.listOf(mountTypes).suchThat(_.nonEmpty)
-
-  val mountGen = for {
-    mountType <- mount
-    description <- Gen.option(longerStrGen)
-    defaultTtl <- Gen.option(Gen.posNum[Int])
-    maxTtl <- Gen.option(Gen.posNum[Int])
-    forceNoCache <- Gen.option(Gen.oneOf(true, false))
-  } yield Mount(mountType, description, Some(MountConfig(defaultTtl, maxTtl, forceNoCache)))
-
-  def processMountTypes(op: (Result[String, Response], String) => Result[String,
-    Response]) =
-      mountTypes.foldLeft[Result[String, Response]](Result.ok(new
-        JDKResponse(null, null, null)))(op)
-
-}
+//package janstenpickle.vault.manage
+//
+//import com.ning.http.client.Response
+//import com.ning.http.client.providers.jdk.JDKResponse
+//import janstenpickle.vault.core.VaultSpec
+//import janstenpickle.vault.manage.Model.{Mount, MountConfig}
+//import org.scalacheck.{Gen, Prop}
+//import org.specs2.ScalaCheck
+//import janstenpickle.scala.Result
+//
+//class MountIT extends VaultSpec with ScalaCheck {
+//  import MountIT._
+//  import VaultSpec._
+//
+//  def is =
+//    s2"""
+//      Can enable, remount and disable a valid mount $happy
+//      Can enable, list and then disable valid mounts $listSuccess
+//      Cannot enable an invalid mount type $enableFail
+//    """
+//
+//  lazy val underTest = new Mounts(config)
+//
+//  def happy = Prop.forAllNoShrink(
+//    mountGen,
+//    longerStrGen,
+//    longerStrGen,
+//    Gen.option(longerStrGen))((mount, mountPoint, remountPoint, desc) => {
+//      (underTest.mount(mount.`type`, Some(mountPoint), desc, Some(mount))
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.remount(mountPoint, remountPoint)
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.delete(remountPoint)
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.delete(mountPoint)
+//      .attemptRun(_.getMessage()) must beOk)
+//    })
+//
+//  def listSuccess = (processMountTypes((acc, mount) =>
+//    acc.flatMap(_ => underTest.mount(mount)
+//    .attemptRun(_.getMessage()))) must beOk) and
+//    (underTest.list.attemptRun(_.getMessage()) must beOk.like {
+//      case a => a.map(_._2.`type`) must containAllOf(mountTypes)
+//    }) and
+//    (processMountTypes((acc, mount) =>
+//      acc.flatMap(_ =>
+//          underTest.delete(mount).attemptRun(_.getMessage()))
+//    ) must beOk)
+//
+//  def enableFail = Prop.forAllNoShrink(
+//    longerStrGen.suchThat(!mountTypes.contains(_)),
+//    longerStrGen,
+//    Gen.option(longerStrGen))((`type`, mount, desc) =>
+//      underTest.mount(`type`, Some(mount), desc)
+//        .attemptRun(_.getMessage()) must beFail
+//  )
+//
+//}
+//
+//object MountIT {
+//  import VaultSpec._
+//
+//  val mountTypes = List(
+//    "aws", "cassandra", "consul", "generic",
+//    "mssql", "mysql", "pki", "postgresql", "ssh", "transit"
+//  )
+//  val mount = Gen.oneOf(mountTypes)
+//  val mounts = Gen.listOf(mountTypes).suchThat(_.nonEmpty)
+//
+//  val mountGen = for {
+//    mountType <- mount
+//    description <- Gen.option(longerStrGen)
+//    defaultTtl <- Gen.option(Gen.posNum[Int])
+//    maxTtl <- Gen.option(Gen.posNum[Int])
+//    forceNoCache <- Gen.option(Gen.oneOf(true, false))
+//  } yield Mount(mountType, description, Some(MountConfig(defaultTtl, maxTtl, forceNoCache)))
+//
+//  def processMountTypes(op: (Result[String, Response], String) => Result[String,
+//    Response]) =
+//      mountTypes.foldLeft[Result[String, Response]](Result.ok(new
+//        JDKResponse(null, null, null)))(op)
+//
+//}

--- a/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/MountIT.scala
@@ -79,9 +79,8 @@ object MountIT {
     forceNoCache <- Gen.option(Gen.oneOf(true, false))
   } yield Mount(mountType, description, Some(MountConfig(defaultTtl, maxTtl, forceNoCache)))
 
-  def processMountTypes(op: (Result[String, Response], String) => Result[String,
-    Response]) =
-      mountTypes.foldLeft[Result[String, Response]](Result.pure(new
+  def processMountTypes(op: (Result[Response], String) => Result[Response]) =
+      mountTypes.foldLeft[Result[Response]](Result.pure(new
         JDKResponse(null, null, null)))(op)
 
 }

--- a/manage/src/it/scala/janstenpickle/vault/manage/PolicyIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/PolicyIT.scala
@@ -1,57 +1,58 @@
-//package janstenpickle.vault.manage
-//
-//import janstenpickle.vault.core.VaultSpec
-//import janstenpickle.vault.manage.Model.Rule
-//import org.scalacheck.{Gen, Prop}
-//import org.specs2.ScalaCheck
-//import uscala.result.Result
-//
-//class PolicyIT extends VaultSpec with ScalaCheck {
-//  import PolicyIT._
-//  import VaultSpec._
-//
-//  override def is =
-//    s2"""
-//      Can successfully set and get policies $happy
-//      Cannot set an invalid policy $sad
-//    """
-//
-//  lazy val underTest = Policy(config)
-//
-//  def happy = Prop.forAllNoShrink(
-//    longerStrGen,
-//    Gen.listOf(ruleGen(longerStrGen, policyGen, capabilitiesGen)).
-//    suchThat(_.nonEmpty)) { (name, rules) =>
-//      (underTest.set(name.toLowerCase, rules)
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.inspect(name.toLowerCase)
-//      .attemptRun(_.getMessage()) must beOk) and
-//      (underTest.delete(name.toLowerCase).attemptRun(_.getMessage()) must beOk)
-//  }
-//
-//  // cannot use generated values here as
-//  // vault seems to have a failure rate limit
-//  def sad = underTest.set(
-//    "nic", List(Rule("cage", Some(List("kim", "copolla"))))
-//  ).attemptRun(_.getMessage()) must beFail
-//}
-//
-//object PolicyIT {
-//  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
-//  val capabilitiesGen =
-//    Gen.listOf(Gen.oneOf(
-//      "create", "read", "update", "delete", "list", "sudo", "deny")).
-//      suchThat(_.nonEmpty).
-//      map(_.distinct)
-//
-//  def ruleGen(
-//    pathGen: Gen[String],
-//    polGen: Gen[Option[String]],
-//    capGen: Gen[List[String]]
-//  ) = for {
-//    path <- pathGen
-//    policy <- polGen
-//    capabilities <- capGen
-//  } yield Rule(path, Some(capabilities), policy)
-//}
-//
+package janstenpickle.vault.manage
+
+import janstenpickle.vault.core.VaultSpec
+import janstenpickle.vault.manage.Model.Rule
+import org.scalacheck.{Gen, Prop}
+import org.specs2.ScalaCheck
+import janstenpickle.scala.syntax.AsyncResultSyntax._
+import org.specs2.matcher.EitherMatchers
+
+class PolicyIT extends VaultSpec with ScalaCheck with EitherMatchers {
+  import PolicyIT._
+  import VaultSpec._
+
+  override def is =
+    s2"""
+      Can successfully set and get policies $happy
+      Cannot set an invalid policy $sad
+    """
+
+  lazy val underTest = Policy(config)
+
+  def happy = Prop.forAllNoShrink(
+    longerStrGen,
+    Gen.listOf(ruleGen(longerStrGen, policyGen, capabilitiesGen)).
+    suchThat(_.nonEmpty)) { (name, rules) =>
+      (underTest.set(name.toLowerCase, rules)
+      .attemptRun must beRight) and
+      (underTest.inspect(name.toLowerCase)
+        .attemptRun must beRight) and
+      (underTest.delete(name.toLowerCase).attemptRun must beRight)
+  }
+
+  // cannot use generated values here as
+  // vault seems to have a failure rate limit
+  def sad = underTest.set(
+    "nic", List(Rule("cage", Some(List("kim", "copolla"))))
+  ).attemptRun must beLeft
+}
+
+object PolicyIT {
+  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
+  val capabilitiesGen =
+    Gen.listOf(Gen.oneOf(
+      "create", "read", "update", "delete", "list", "sudo", "deny")).
+      suchThat(_.nonEmpty).
+      map(_.distinct)
+
+  def ruleGen(
+    pathGen: Gen[String],
+    polGen: Gen[Option[String]],
+    capGen: Gen[List[String]]
+  ) = for {
+    path <- pathGen
+    policy <- polGen
+    capabilities <- capGen
+  } yield Rule(path, Some(capabilities), policy)
+}
+

--- a/manage/src/it/scala/janstenpickle/vault/manage/PolicyIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/PolicyIT.scala
@@ -1,57 +1,57 @@
-package janstenpickle.vault.manage
-
-import janstenpickle.vault.core.VaultSpec
-import janstenpickle.vault.manage.Model.Rule
-import org.scalacheck.{Gen, Prop}
-import org.specs2.ScalaCheck
-import uscala.result.Result
-
-class PolicyIT extends VaultSpec with ScalaCheck {
-  import PolicyIT._
-  import VaultSpec._
-
-  override def is =
-    s2"""
-      Can successfully set and get policies $happy
-      Cannot set an invalid policy $sad
-    """
-
-  lazy val underTest = Policy(config)
-
-  def happy = Prop.forAllNoShrink(
-    longerStrGen,
-    Gen.listOf(ruleGen(longerStrGen, policyGen, capabilitiesGen)).
-    suchThat(_.nonEmpty)) { (name, rules) =>
-      (underTest.set(name.toLowerCase, rules)
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.inspect(name.toLowerCase)
-      .attemptRun(_.getMessage()) must beOk) and
-      (underTest.delete(name.toLowerCase).attemptRun(_.getMessage()) must beOk)
-  }
-
-  // cannot use generated values here as
-  // vault seems to have a failure rate limit
-  def sad = underTest.set(
-    "nic", List(Rule("cage", Some(List("kim", "copolla"))))
-  ).attemptRun(_.getMessage()) must beFail
-}
-
-object PolicyIT {
-  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
-  val capabilitiesGen =
-    Gen.listOf(Gen.oneOf(
-      "create", "read", "update", "delete", "list", "sudo", "deny")).
-      suchThat(_.nonEmpty).
-      map(_.distinct)
-
-  def ruleGen(
-    pathGen: Gen[String],
-    polGen: Gen[Option[String]],
-    capGen: Gen[List[String]]
-  ) = for {
-    path <- pathGen
-    policy <- polGen
-    capabilities <- capGen
-  } yield Rule(path, Some(capabilities), policy)
-}
-
+//package janstenpickle.vault.manage
+//
+//import janstenpickle.vault.core.VaultSpec
+//import janstenpickle.vault.manage.Model.Rule
+//import org.scalacheck.{Gen, Prop}
+//import org.specs2.ScalaCheck
+//import uscala.result.Result
+//
+//class PolicyIT extends VaultSpec with ScalaCheck {
+//  import PolicyIT._
+//  import VaultSpec._
+//
+//  override def is =
+//    s2"""
+//      Can successfully set and get policies $happy
+//      Cannot set an invalid policy $sad
+//    """
+//
+//  lazy val underTest = Policy(config)
+//
+//  def happy = Prop.forAllNoShrink(
+//    longerStrGen,
+//    Gen.listOf(ruleGen(longerStrGen, policyGen, capabilitiesGen)).
+//    suchThat(_.nonEmpty)) { (name, rules) =>
+//      (underTest.set(name.toLowerCase, rules)
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.inspect(name.toLowerCase)
+//      .attemptRun(_.getMessage()) must beOk) and
+//      (underTest.delete(name.toLowerCase).attemptRun(_.getMessage()) must beOk)
+//  }
+//
+//  // cannot use generated values here as
+//  // vault seems to have a failure rate limit
+//  def sad = underTest.set(
+//    "nic", List(Rule("cage", Some(List("kim", "copolla"))))
+//  ).attemptRun(_.getMessage()) must beFail
+//}
+//
+//object PolicyIT {
+//  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
+//  val capabilitiesGen =
+//    Gen.listOf(Gen.oneOf(
+//      "create", "read", "update", "delete", "list", "sudo", "deny")).
+//      suchThat(_.nonEmpty).
+//      map(_.distinct)
+//
+//  def ruleGen(
+//    pathGen: Gen[String],
+//    polGen: Gen[Option[String]],
+//    capGen: Gen[List[String]]
+//  ) = for {
+//    path <- pathGen
+//    policy <- polGen
+//    capabilities <- capGen
+//  } yield Rule(path, Some(capabilities), policy)
+//}
+//

--- a/manage/src/it/scala/janstenpickle/vault/manage/UserPassIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/UserPassIT.scala
@@ -1,51 +1,51 @@
-package janstenpickle.vault.manage
-
-import janstenpickle.vault.core.VaultSpec
-import org.scalacheck.{Gen, Prop}
-import org.specs2.ScalaCheck
-
-class UserPassIT extends VaultSpec with ScalaCheck {
-  import UserPassIT._
-  import VaultSpec._
-
-  def is =
-    s2"""
-      Can create, update and delete a user $good
-      Cannot create a user for a non-existent client $badClient
-      Cannot create user with a bad policy $badPolicy
-    """
-
-  lazy val underTest = UserPass(config)
-  lazy val authAdmin = Auth(config)
-
-  def good = Prop.forAllNoShrink(longerStrGen, longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen, policyGen)(
-    (username, password, newPassword, ttl, client, policy) =>
-      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
-      (underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beOk) and
-      (underTest.setPassword(username, newPassword, client).attemptRun(_.getMessage()) must beOk) and
-      (underTest.setPolicies(username, policy, client).attemptRun(_.getMessage()) must beOk) and
-      (underTest.delete(username, client).attemptRun(_.getMessage()) must beOk) and
-      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
-  )
-
-  def badClient = Prop.forAllNoShrink(longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen)(
-    (username, password, ttl, client) =>
-      underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beFail
-  )
-
-  def badPolicy = Prop.forAllNoShrink(longerStrGen,
-                                      longerStrGen,
-                                      Gen.posNum[Int],
-                                      longerStrGen,
-                                      Gen.listOf(longerStrGen.suchThat(!policies.contains(_))))(
-    (username, password, ttl, client, policy) =>
-      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
-      (underTest.create(username, password, ttl, Some(policy), client).attemptRun(_.getMessage()) must beOk) and
-      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
-  )
-}
-
-object UserPassIT {
-  val policies = List("default", "root")
-  val policyGen = Gen.listOf(Gen.oneOf(policies))
-}
+//package janstenpickle.vault.manage
+//
+//import janstenpickle.vault.core.VaultSpec
+//import org.scalacheck.{Gen, Prop}
+//import org.specs2.ScalaCheck
+//
+//class UserPassIT extends VaultSpec with ScalaCheck {
+//  import UserPassIT._
+//  import VaultSpec._
+//
+//  def is =
+//    s2"""
+//      Can create, update and delete a user $good
+//      Cannot create a user for a non-existent client $badClient
+//      Cannot create user with a bad policy $badPolicy
+//    """
+//
+//  lazy val underTest = UserPass(config)
+//  lazy val authAdmin = Auth(config)
+//
+//  def good = Prop.forAllNoShrink(longerStrGen, longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen, policyGen)(
+//    (username, password, newPassword, ttl, client, policy) =>
+//      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
+//      (underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beOk) and
+//      (underTest.setPassword(username, newPassword, client).attemptRun(_.getMessage()) must beOk) and
+//      (underTest.setPolicies(username, policy, client).attemptRun(_.getMessage()) must beOk) and
+//      (underTest.delete(username, client).attemptRun(_.getMessage()) must beOk) and
+//      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
+//  )
+//
+//  def badClient = Prop.forAllNoShrink(longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen)(
+//    (username, password, ttl, client) =>
+//      underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beFail
+//  )
+//
+//  def badPolicy = Prop.forAllNoShrink(longerStrGen,
+//                                      longerStrGen,
+//                                      Gen.posNum[Int],
+//                                      longerStrGen,
+//                                      Gen.listOf(longerStrGen.suchThat(!policies.contains(_))))(
+//    (username, password, ttl, client, policy) =>
+//      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
+//      (underTest.create(username, password, ttl, Some(policy), client).attemptRun(_.getMessage()) must beOk) and
+//      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
+//  )
+//}
+//
+//object UserPassIT {
+//  val policies = List("default", "root")
+//  val policyGen = Gen.listOf(Gen.oneOf(policies))
+//}

--- a/manage/src/it/scala/janstenpickle/vault/manage/UserPassIT.scala
+++ b/manage/src/it/scala/janstenpickle/vault/manage/UserPassIT.scala
@@ -1,51 +1,53 @@
-//package janstenpickle.vault.manage
-//
-//import janstenpickle.vault.core.VaultSpec
-//import org.scalacheck.{Gen, Prop}
-//import org.specs2.ScalaCheck
-//
-//class UserPassIT extends VaultSpec with ScalaCheck {
-//  import UserPassIT._
-//  import VaultSpec._
-//
-//  def is =
-//    s2"""
-//      Can create, update and delete a user $good
-//      Cannot create a user for a non-existent client $badClient
-//      Cannot create user with a bad policy $badPolicy
-//    """
-//
-//  lazy val underTest = UserPass(config)
-//  lazy val authAdmin = Auth(config)
-//
-//  def good = Prop.forAllNoShrink(longerStrGen, longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen, policyGen)(
-//    (username, password, newPassword, ttl, client, policy) =>
-//      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
-//      (underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beOk) and
-//      (underTest.setPassword(username, newPassword, client).attemptRun(_.getMessage()) must beOk) and
-//      (underTest.setPolicies(username, policy, client).attemptRun(_.getMessage()) must beOk) and
-//      (underTest.delete(username, client).attemptRun(_.getMessage()) must beOk) and
-//      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
-//  )
-//
-//  def badClient = Prop.forAllNoShrink(longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen)(
-//    (username, password, ttl, client) =>
-//      underTest.create(username, password, ttl, None, client).attemptRun(_.getMessage()) must beFail
-//  )
-//
-//  def badPolicy = Prop.forAllNoShrink(longerStrGen,
-//                                      longerStrGen,
-//                                      Gen.posNum[Int],
-//                                      longerStrGen,
-//                                      Gen.listOf(longerStrGen.suchThat(!policies.contains(_))))(
-//    (username, password, ttl, client, policy) =>
-//      (authAdmin.enable("userpass", Some(client)).attemptRun(_.getMessage()) must beOk) and
-//      (underTest.create(username, password, ttl, Some(policy), client).attemptRun(_.getMessage()) must beOk) and
-//      (authAdmin.disable(client).attemptRun(_.getMessage()) must beOk)
-//  )
-//}
-//
-//object UserPassIT {
-//  val policies = List("default", "root")
-//  val policyGen = Gen.listOf(Gen.oneOf(policies))
-//}
+package janstenpickle.vault.manage
+
+import janstenpickle.vault.core.VaultSpec
+import org.scalacheck.{Gen, Prop}
+import org.specs2.ScalaCheck
+import janstenpickle.scala.syntax.AsyncResultSyntax._
+import org.specs2.matcher.EitherMatchers
+
+class UserPassIT extends VaultSpec with ScalaCheck with EitherMatchers {
+  import UserPassIT._
+  import VaultSpec._
+
+  def is =
+    s2"""
+      Can create, update and delete a user $good
+      Cannot create a user for a non-existent client $badClient
+      Cannot create user with a bad policy $badPolicy
+    """
+
+  lazy val underTest = UserPass(config)
+  lazy val authAdmin = Auth(config)
+
+  def good = Prop.forAllNoShrink(longerStrGen, longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen, policyGen)(
+    (username, password, newPassword, ttl, client, policy) =>
+      (authAdmin.enable("userpass", Some(client)).attemptRun must beRight) and
+      (underTest.create(username, password, ttl, None, client).attemptRun must beRight) and
+      (underTest.setPassword(username, newPassword, client).attemptRun must beRight) and
+      (underTest.setPolicies(username, policy, client).attemptRun must beRight) and
+      (underTest.delete(username, client).attemptRun must beRight) and
+      (authAdmin.disable(client).attemptRun must beRight)
+  )
+
+  def badClient = Prop.forAllNoShrink(longerStrGen, longerStrGen, Gen.posNum[Int], longerStrGen)(
+    (username, password, ttl, client) =>
+      underTest.create(username, password, ttl, None, client).attemptRun must beLeft
+  )
+
+  def badPolicy = Prop.forAllNoShrink(longerStrGen,
+                                      longerStrGen,
+                                      Gen.posNum[Int],
+                                      longerStrGen,
+                                      Gen.listOf(longerStrGen.suchThat(!policies.contains(_))))(
+    (username, password, ttl, client, policy) =>
+      (authAdmin.enable("userpass", Some(client)).attemptRun must beRight) and
+      (underTest.create(username, password, ttl, Some(policy), client).attemptRun must beRight) and
+      (authAdmin.disable(client).attemptRun must beRight)
+  )
+}
+
+object UserPassIT {
+  val policies = List("default", "root")
+  val policyGen = Gen.listOf(Gen.oneOf(policies))
+}

--- a/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
@@ -6,7 +6,7 @@ import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._
 import janstenpickle.vault.core.VaultConfig
-import uscala.concurrent.result.AsyncResult
+import janstenpickle.scala.Result._
 
 import scala.concurrent.ExecutionContext
 

--- a/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
@@ -18,7 +18,7 @@ case class UserPass(config: VaultConfig) {
              ttl: Int,
              policies: Option[List[String]] = None,
              client: String = DefaultClient)
-            (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+            (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"auth/$client/users/$username")(
       _.post(policies.map(_.mkString(",")).toMap("policies") ++
                          Map("username" -> username,
@@ -27,7 +27,7 @@ case class UserPass(config: VaultConfig) {
     ).execute.acceptStatusCodes(204)
 
   def delete(username: String, client: String = DefaultClient)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"auth/$client/users/$username")(_.delete).
       execute.
       acceptStatusCodes(204)
@@ -36,7 +36,7 @@ case class UserPass(config: VaultConfig) {
     username: String,
     password: String,
     client: String = DefaultClient
-  )(implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  )(implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"auth/$client/users/$username/password")(
       _.post(Map("username" -> username, "password" -> password))
     ).execute.acceptStatusCodes(204)
@@ -45,7 +45,7 @@ case class UserPass(config: VaultConfig) {
     username: String,
     policies: List[String],
     client: String = DefaultClient
-  )(implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  )(implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"auth/$client/users/$username/policies")(
       _.post(Map("username" -> username, "policies" -> policies.mkString(",")))
     ).execute.acceptStatusCodes(204)

--- a/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/UserPass.scala
@@ -6,7 +6,7 @@ import janstenpickle.scala.syntax.SyntaxRequest._
 import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._
 import janstenpickle.vault.core.VaultConfig
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 
 import scala.concurrent.ExecutionContext
 

--- a/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
@@ -9,8 +9,7 @@ import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._
 import janstenpickle.vault.core.VaultConfig
 import janstenpickle.vault.manage.Model._
-import janstenpickle.scala.Result
-import janstenpickle.scala.Result._
+import janstenpickle.scala.result._
 
 import scala.concurrent.ExecutionContext
 

--- a/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
@@ -18,13 +18,13 @@ case class Auth(config: VaultConfig) {
   def enable(`type`: String,
              mountPoint: Option[String] = None,
              description: Option[String] = None)
-            (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+            (implicit ec: ExecutionContext): AsyncResult[Response] =
      config.authenticatedRequest(s"sys/auth/${mountPoint.getOrElse(`type`)}")(
        _.post(description.toMap("description") + ("type" -> `type`))
      ).execute.acceptStatusCodes(204)
 
   def disable(mountPoint: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"sys/auth/$mountPoint")(_.delete).
       execute.
       acceptStatusCodes(204)
@@ -32,13 +32,13 @@ case class Auth(config: VaultConfig) {
 
 case class Mounts(config: VaultConfig) {
   def remount(from: String, to: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest("sys/remount")(
       _.post(Map("from" -> from, "to" -> to))
     ).execute.acceptStatusCodes(204)
 
   def list(implicit ec: ExecutionContext):
-  AsyncResult[String, Map[String, Mount]] =
+  AsyncResult[Map[String, Mount]] =
     config.authenticatedRequest("sys/mounts")(_.get).
       execute.
       acceptStatusCodes(200).
@@ -48,13 +48,13 @@ case class Mounts(config: VaultConfig) {
             mountPoint: Option[String] = None,
             description: Option[String] = None,
             conf: Option[Mount] = None)
-           (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+           (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"sys/mounts/${mountPoint.getOrElse(`type`)}")(
       _.post(MountRequest(`type`, description, conf).asJson)
     ).execute.acceptStatusCodes(204)
 
   def delete(mountPoint: String)
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"sys/mounts/$mountPoint")(_.delete).
       execute.
       acceptStatusCodes(204)
@@ -62,7 +62,7 @@ case class Mounts(config: VaultConfig) {
 
 case class Policy(config: VaultConfig) {
 
-  def list(implicit ec: ExecutionContext): AsyncResult[String, List[String]] =
+  def list(implicit ec: ExecutionContext): AsyncResult[List[String]] =
     config.authenticatedRequest("sys/policy")(_.get).
       execute.
       acceptStatusCodes(200).
@@ -70,21 +70,21 @@ case class Policy(config: VaultConfig) {
 
   // NOTE: `rules` is not valid Json
   def inspect(policy: String)(implicit ec: ExecutionContext):
-  AsyncResult[String, String] =
+  AsyncResult[String] =
     config.authenticatedRequest(s"sys/policy/$policy")(_.get).
       execute.
       acceptStatusCodes(200)
       .extractFromJson[String](_.downField("rules"))
 
   def set(policy: String, rules: List[Rule])
-  (implicit ec: ExecutionContext): AsyncResult[String, Response] =
+  (implicit ec: ExecutionContext): AsyncResult[Response] =
     config.authenticatedRequest(s"sys/policy/$policy")(
       _.post(PolicySetting(policy, rules).asJson)).
       execute.
       acceptStatusCodes(204)
 
   def delete(policy: String)(implicit ec: ExecutionContext):
-  AsyncResult[String, Response] =
+  AsyncResult[Response] =
     config.authenticatedRequest(s"sys/policy/$policy")(_.delete).
       execute.
       acceptStatusCodes(204)
@@ -104,7 +104,7 @@ object Model {
   )
 
   case class PolicySetting(name: String, rules: Option[String]) {
-    lazy val decodeRules: Option[Result[String, List[Rule]]] = rules.filter(
+    lazy val decodeRules: Option[Result[List[Rule]]] = rules.filter(
       _.nonEmpty).map(Rule.decode)
   }
   object PolicySetting {
@@ -136,7 +136,7 @@ object Model {
     val capabilitiesRegex = """\s+capabilities\s+=\s+\[(.+)\]""".r
     val policyRegex = """\s+policy\s+=\s+"(\S+)"""".r
 
-    def decode(ruleString: String): Result[String, List[Rule]] = {
+    def decode(ruleString: String): Result[List[Rule]] = {
       val rules = ruleString.split("""\s*}\s+\n""").toList
       val decoded = rules.foldLeft(List.empty[Rule])( (acc, v) =>
         acc ++ pathRegex.findFirstMatchIn(v).map(_.group(1)).map(path =>

--- a/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
+++ b/manage/src/main/scala/janstenpickle/vault/manage/manage.scala
@@ -9,8 +9,8 @@ import janstenpickle.scala.syntax.ResponseSyntax._
 import janstenpickle.scala.syntax.VaultConfigSyntax._
 import janstenpickle.vault.core.VaultConfig
 import janstenpickle.vault.manage.Model._
-import uscala.concurrent.result.AsyncResult
-import uscala.result.Result
+import janstenpickle.scala.Result
+import janstenpickle.scala.Result._
 
 import scala.concurrent.ExecutionContext
 
@@ -150,10 +150,10 @@ object Model {
         )
       )
       if (decoded.isEmpty) {
-        Result.fail(s"Could not find any valid rules in string: $ruleString")
+        Result fail s"Could not find any valid rules in string: $ruleString"
       }
       else {
-        Result.ok(decoded)
+        Result pure decoded
       }
     }
   }

--- a/manage/src/test/scala/janstenpickle/vault/manage/RuleSpec.scala
+++ b/manage/src/test/scala/janstenpickle/vault/manage/RuleSpec.scala
@@ -1,51 +1,51 @@
-//package janstenpickle.vault.manage
-//
-//import janstenpickle.vault.manage.Model.Rule
-//import org.scalacheck.{Gen, Prop}
-//import org.specs2.{ScalaCheck, Specification}
-//import uscala.result.specs2.ResultMatchers
-//
-//class RuleSpec extends Specification with ScalaCheck with ResultMatchers {
-//  import RuleSpec._
-//
-//  override def is =
-//    s2"""
-//      Can encode and decode policy strings $passes
-//      Cannot decode bad policy strings $fails
-//      """
-//
-//  def passes = Prop.forAllNoShrink(Gen.listOf(ruleGen).suchThat(_.nonEmpty)) (rules =>
-//    Rule.decode(rules.map(_.encode).mkString("\n")) must beOk.like {
-//      case a => a must containAllOf(rules)
-//    }
-//  )
-//
-//  def fails = Prop.forAllNoShrink(Gen.listOf(badRuleGen).suchThat(_.nonEmpty)) (rules =>
-//    Rule.decode(rules.mkString("\n")) must beFail
-//  )
-//}
-//
-//object RuleSpec {
-//  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
-//  val capabilitiesGen = Gen.option(
-//    Gen.listOf(Gen.oneOf("create", "read", "update", "delete", "list", "sudo", "deny")).
-//      suchThat(_.nonEmpty).
-//      map(_.distinct)
-//  )
-//
-//  val ruleGen = for {
-//    path <- Gen.alphaStr.suchThat(_.nonEmpty)
-//    policy <- policyGen
-//    capabilities <- capabilitiesGen
-//  } yield Rule(path, capabilities, policy)
-//
-//  val badRuleGen = for {
-//    path <- Gen.alphaStr.suchThat(_.nonEmpty)
-//    policy <- policyGen
-//    capabilities <- capabilitiesGen
-//  } yield
-//    s"""
-//       |path "$path"
-//       |   $policy cage
-//       |   $capabilities }""".stripMargin('|')
-//}
+package janstenpickle.vault.manage
+
+import janstenpickle.vault.manage.Model.Rule
+import org.scalacheck.{Gen, Prop}
+import org.specs2.matcher.EitherMatchers
+import org.specs2.{ScalaCheck, Specification}
+
+class RuleSpec extends Specification with ScalaCheck with EitherMatchers {
+  import RuleSpec._
+
+  override def is =
+    s2"""
+      Can encode and decode policy strings $passes
+      Cannot decode bad policy strings $fails
+      """
+
+  def passes = Prop.forAllNoShrink(Gen.listOf(ruleGen).suchThat(_.nonEmpty)) (rules =>
+    Rule.decode(rules.map(_.encode).mkString("\n")) must beRight.like {
+      case a => a must containAllOf(rules)
+    }
+  )
+
+  def fails = Prop.forAllNoShrink(Gen.listOf(badRuleGen).suchThat(_.nonEmpty)) (rules =>
+    Rule.decode(rules.mkString("\n")) must beLeft
+  )
+}
+
+object RuleSpec {
+  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
+  val capabilitiesGen = Gen.option(
+    Gen.listOf(Gen.oneOf("create", "read", "update", "delete", "list", "sudo", "deny")).
+      suchThat(_.nonEmpty).
+      map(_.distinct)
+  )
+
+  val ruleGen = for {
+    path <- Gen.alphaStr.suchThat(_.nonEmpty)
+    policy <- policyGen
+    capabilities <- capabilitiesGen
+  } yield Rule(path, capabilities, policy)
+
+  val badRuleGen = for {
+    path <- Gen.alphaStr.suchThat(_.nonEmpty)
+    policy <- policyGen
+    capabilities <- capabilitiesGen
+  } yield
+    s"""
+       |path "$path"
+       |   $policy cage
+       |   $capabilities }""".stripMargin('|')
+}

--- a/manage/src/test/scala/janstenpickle/vault/manage/RuleSpec.scala
+++ b/manage/src/test/scala/janstenpickle/vault/manage/RuleSpec.scala
@@ -1,51 +1,51 @@
-package janstenpickle.vault.manage
-
-import janstenpickle.vault.manage.Model.Rule
-import org.scalacheck.{Gen, Prop}
-import org.specs2.{ScalaCheck, Specification}
-import uscala.result.specs2.ResultMatchers
-
-class RuleSpec extends Specification with ScalaCheck with ResultMatchers {
-  import RuleSpec._
-
-  override def is =
-    s2"""
-      Can encode and decode policy strings $passes
-      Cannot decode bad policy strings $fails
-      """
-
-  def passes = Prop.forAllNoShrink(Gen.listOf(ruleGen).suchThat(_.nonEmpty)) (rules =>
-    Rule.decode(rules.map(_.encode).mkString("\n")) must beOk.like {
-      case a => a must containAllOf(rules)
-    }
-  )
-
-  def fails = Prop.forAllNoShrink(Gen.listOf(badRuleGen).suchThat(_.nonEmpty)) (rules =>
-    Rule.decode(rules.mkString("\n")) must beFail
-  )
-}
-
-object RuleSpec {
-  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
-  val capabilitiesGen = Gen.option(
-    Gen.listOf(Gen.oneOf("create", "read", "update", "delete", "list", "sudo", "deny")).
-      suchThat(_.nonEmpty).
-      map(_.distinct)
-  )
-
-  val ruleGen = for {
-    path <- Gen.alphaStr.suchThat(_.nonEmpty)
-    policy <- policyGen
-    capabilities <- capabilitiesGen
-  } yield Rule(path, capabilities, policy)
-
-  val badRuleGen = for {
-    path <- Gen.alphaStr.suchThat(_.nonEmpty)
-    policy <- policyGen
-    capabilities <- capabilitiesGen
-  } yield
-    s"""
-       |path "$path"
-       |   $policy cage
-       |   $capabilities }""".stripMargin('|')
-}
+//package janstenpickle.vault.manage
+//
+//import janstenpickle.vault.manage.Model.Rule
+//import org.scalacheck.{Gen, Prop}
+//import org.specs2.{ScalaCheck, Specification}
+//import uscala.result.specs2.ResultMatchers
+//
+//class RuleSpec extends Specification with ScalaCheck with ResultMatchers {
+//  import RuleSpec._
+//
+//  override def is =
+//    s2"""
+//      Can encode and decode policy strings $passes
+//      Cannot decode bad policy strings $fails
+//      """
+//
+//  def passes = Prop.forAllNoShrink(Gen.listOf(ruleGen).suchThat(_.nonEmpty)) (rules =>
+//    Rule.decode(rules.map(_.encode).mkString("\n")) must beOk.like {
+//      case a => a must containAllOf(rules)
+//    }
+//  )
+//
+//  def fails = Prop.forAllNoShrink(Gen.listOf(badRuleGen).suchThat(_.nonEmpty)) (rules =>
+//    Rule.decode(rules.mkString("\n")) must beFail
+//  )
+//}
+//
+//object RuleSpec {
+//  val policyGen = Gen.option(Gen.oneOf("read", "write", "sudo", "deny"))
+//  val capabilitiesGen = Gen.option(
+//    Gen.listOf(Gen.oneOf("create", "read", "update", "delete", "list", "sudo", "deny")).
+//      suchThat(_.nonEmpty).
+//      map(_.distinct)
+//  )
+//
+//  val ruleGen = for {
+//    path <- Gen.alphaStr.suchThat(_.nonEmpty)
+//    policy <- policyGen
+//    capabilities <- capabilitiesGen
+//  } yield Rule(path, capabilities, policy)
+//
+//  val badRuleGen = for {
+//    path <- Gen.alphaStr.suchThat(_.nonEmpty)
+//    policy <- policyGen
+//    capabilities <- capabilitiesGen
+//  } yield
+//    s"""
+//       |path "$path"
+//       |   $policy cage
+//       |   $capabilities }""".stripMargin('|')
+//}


### PR DESCRIPTION
This is still a wip:
- [x] remove dependency on uscala, use cats
- [x] create type aliases that are syntactically similar to uscala, and use those
- [x] fix tests and ensure that they pass using new cats backed implementation
- [x] simplify types. `type AsyncEitherT[R] = cats.data.EitherT[Future, String, R]`. AsyncResult can bear to lose the generic "failure" type, and have it be fixed at `String`
- [ ] final sanity cleanup